### PR TITLE
Ignore rectangles within an ApplicationStructureBody

### DIFF
--- a/src/net/sf/jcgm/core/ApplicationStructureAttribute.java
+++ b/src/net/sf/jcgm/core/ApplicationStructureAttribute.java
@@ -1,0 +1,37 @@
+package net.sf.jcgm.core;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+/**
+ * Class=9, Element=1
+ * 
+ * @author diaa (daviddiana11)
+ * @version $Id$
+ * @since Jul 26, 2022
+ */
+public class ApplicationStructureAttribute extends Command {
+
+    private final String applicationStructureAttributeType;
+    private final StructuredDataRecord sdr;
+    
+    public ApplicationStructureAttribute(int ec, int eid, int l, DataInput in) throws IOException {
+        super(ec, eid, l, in);
+        
+        // application structure attribute type (SF)
+        this.applicationStructureAttributeType = makeString();
+        
+        // data record (SDR)
+        this.sdr = makeSDR();
+        
+        assert this.currentArg == this.args.length;
+    }
+
+    @Override
+    public String toString() {
+        return "Unsupported - ApplicationStructureAttribute [" +
+                "applicationStructureAttributeType='" + this.applicationStructureAttributeType + '\'' +
+                ", sdr=" + this.sdr +
+                ']';
+    }
+}

--- a/src/net/sf/jcgm/core/ApplicationStructureDescriptorElement.java
+++ b/src/net/sf/jcgm/core/ApplicationStructureDescriptorElement.java
@@ -1,0 +1,33 @@
+package net.sf.jcgm.core;
+
+/**
+ * Element class 9: Application Structure Descriptor
+ *
+ * @author diaa (daviddiana11)
+ * @version $Id$
+ * @since Jul 26, 2022
+ */
+public enum ApplicationStructureDescriptorElement {
+
+    UNUSED_0(0),
+    APPLICATION_STRUCTURE_ATTRIBUTE(1),
+    ;
+
+    private final int elementCode;
+
+    ApplicationStructureDescriptorElement(int elementCode) {
+        this.elementCode = elementCode;
+    }
+
+    public static ApplicationStructureDescriptorElement getElement(int ec) {
+        if (ec < 0 || ec >= values().length)
+            throw new ArrayIndexOutOfBoundsException(ec);
+
+        return values()[ec];
+    }
+
+    @Override
+    public String toString() {
+        return name().concat("(").concat(String.valueOf(this.elementCode)).concat(")");
+    }
+}

--- a/src/net/sf/jcgm/core/BeginApplicationStructure.java
+++ b/src/net/sf/jcgm/core/BeginApplicationStructure.java
@@ -1,0 +1,46 @@
+package net.sf.jcgm.core;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+/**
+ * Class=0, Element=21
+ * @author diaa (daviddiana11)
+ * @version $Id$
+ * @since Jul 26, 2022
+ */
+public class BeginApplicationStructure extends Command {
+    
+    private final String applicationStructureIdentifier;
+    private final String applicationStructureType;
+    private final boolean inheritanceFlag;
+    
+    public BeginApplicationStructure(int ec, int eid, int l, DataInput in) throws IOException {
+        super(ec, eid, l, in);
+
+        // application structure identifier (SF)
+        this.applicationStructureIdentifier = makeString();
+        
+        // application structure type (SF)
+        this.applicationStructureType = makeString();
+        
+        // inheritance flag (one of: statelist, application structure) (E)
+        this.inheritanceFlag = makeEnum() >= 1;
+        
+        assert this.currentArg == this.args.length;
+    }
+
+    @Override
+    public void paint(CGMDisplay d) {
+        d.setWithinApplicationStructureBody(true);
+    }
+
+    @Override
+    public String toString() {
+        return "Unsupported - BeginApplicationStructure [" +
+                "applicationStructureIdentifier='" + this.applicationStructureIdentifier + '\'' +
+                ", applicationStructureType='" + this.applicationStructureType + '\'' +
+                ", inheritanceFlag=" + this.inheritanceFlag +
+                ']';
+    }
+}

--- a/src/net/sf/jcgm/core/CGMDisplay.java
+++ b/src/net/sf/jcgm/core/CGMDisplay.java
@@ -153,6 +153,14 @@ public class CGMDisplay {
 
 	/** Cached {@link TextCommand} that if set means that some text is still being appended to the string. */
 	private TextCommand textCommand;
+
+	/**
+	 * //TODO: get rid of this boolean once the "ApplicationStructure"-related commands are supported
+	 * 
+	 * {@code true} if we are currently parsing commands within an ApplicationStructure;
+	 * i.e. between {@link BeginApplicationStructure} and {@link EndApplicationStructure} commands.
+	 */
+	private boolean isWithinApplicationStructureBody = false;
 	
 	public CGMDisplay(CGM cgm) {
 		reset();
@@ -1029,6 +1037,14 @@ public class CGMDisplay {
 	
 	public void resetTextCommand() {
 		this.textCommand = null;
+	}
+
+	public boolean isWithinApplicationStructureBody() {
+		return this.isWithinApplicationStructureBody;
+	}
+
+	public void setWithinApplicationStructureBody(boolean withinApplicationStructureBody) {
+		this.isWithinApplicationStructureBody = withinApplicationStructureBody;
 	}
 }
 

--- a/src/net/sf/jcgm/core/Command.java
+++ b/src/net/sf/jcgm/core/Command.java
@@ -812,8 +812,7 @@ public class Command implements Cloneable {
 			return new Command(ec, eid, l, in);
 
 		case APPLICATION_STRUCTURE_ELEMENTS: // 9
-			unsupported(ec, eid);
-			return new Command(ec, eid, l, in);
+			return readApplicationStructureDescriptorElements(in, ec, eid, l);
 
 		default:
 			assert (10 <= ec && ec <= 15) : "unsupported element class";
@@ -886,7 +885,7 @@ public class Command implements Cloneable {
 			// 0, 21
 		case BEGIN_APPLICATION_STRUCTURE:
 			unsupported(ec, eid);
-			return new Command(ec, eid, l, in);
+			return new BeginApplicationStructure(ec, eid, l, in);
 
 			// 0, 22
 		case BEGIN_APPLICATION_STRUCTURE_BODY:
@@ -1321,6 +1320,17 @@ public class Command implements Cloneable {
 		default:
 			unsupported(ec, eid);
 			return new Command(ec, eid, l, in);
+		}
+	}
+	
+	// Class: 9
+	private static Command readApplicationStructureDescriptorElements(DataInput in, int ec, int eid, int l) throws IOException {
+		switch (ApplicationStructureDescriptorElement.getElement(eid)) {
+			case APPLICATION_STRUCTURE_ATTRIBUTE:
+				return new ApplicationStructureAttribute(ec, eid, l, in);
+			default:
+				unsupported(ec, eid);
+				return new Command(ec, eid, l, in);
 		}
 	}
 

--- a/src/net/sf/jcgm/core/EndApplicationStructure.java
+++ b/src/net/sf/jcgm/core/EndApplicationStructure.java
@@ -21,6 +21,11 @@ public class EndApplicationStructure extends Command {
 	}
 
 	@Override
+	public void paint(CGMDisplay d) {
+		d.setWithinApplicationStructureBody(false);
+	}
+
+	@Override
 	public String toString() {
 		return "EndApplicationStructure";
 	}

--- a/src/net/sf/jcgm/core/RectangleElement.java
+++ b/src/net/sf/jcgm/core/RectangleElement.java
@@ -78,6 +78,11 @@ public class RectangleElement extends Command {
 
     @Override
 	public void paint(CGMDisplay d) {
+        if (d.isWithinApplicationStructureBody()){
+            //TODO: get rid of this check once the "ApplicationStructure"-related commands are supported
+            return;
+        }
+        
     	d.fill(this.shape);
     	
     	Graphics2D g2d = d.getGraphics2D();


### PR DESCRIPTION
* prevented the painting of rectangle when in an _ApplicationStructureBody_ context since all _ApplicationStructure_ commands are not supported yet
**NOTE:** this is to prevent having misplaced rectangles printed on top of the core tiles; the reason why the rectangles painted in an _ApplicationStructureBody_ context are translated is that the affine transformation applied to the core tiles (see _TileElement_ implementation) is not applied to the rectangles.
* added _ApplicationStructure_-related commands classes so we can track them when dumping commands:
   * _ApplicationStructureAttribute_ (class=9, element=1)
   * _BeginApplicationStructure_ (class=0, element=21)
* tested with the [http://docs.oasis-open.org/webcgm/test-materials/webcgm20ts/webcgm20-ts-index.htm](url) files + some OEM samples: no regression spotted

![ignored-rectangle](https://user-images.githubusercontent.com/95964959/181699507-66bd91e9-4c54-4d68-a38b-3504c3f92a16.png)
![before-now](https://user-images.githubusercontent.com/95964959/181697089-9ca47c8e-b3d5-4165-aba0-b92c55d85cc4.png)

