### PR TITLE
Release 0.4.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 <project name="jcgm" default="jar">
 	
 	<!-- The core package -->
-	<property name="version-core" 			value="0.4.0"/>
+	<property name="version-core" 			value="0.4.1"/>
 	<property name="package-name-core" 		value="jcgm-core-${version-core}"/>
 	<property name="jar-name-core" 			value="${package-name-core}.jar"/>
 	<property name="jar-name-core-sources" 	value="${package-name-core}-sources.jar"/>


### PR DESCRIPTION
This release includes a temporary fix that prevents rectangles from being printed when in an ApplicationStructure context, since they are misplaced because of an affine transformation only being applied to the tiles.