### PR TITLE
[FIX] TileElement - temporary TIFF file generation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 <project name="jcgm" default="jar">
 	
 	<!-- The core package -->
-	<property name="version-core" 			value="0.4.1"/>
+	<property name="version-core" 			value="0.4.2"/>
 	<property name="package-name-core" 		value="jcgm-core-${version-core}"/>
 	<property name="jar-name-core" 			value="${package-name-core}.jar"/>
 	<property name="jar-name-core-sources" 	value="${package-name-core}-sources.jar"/>

--- a/src/net/sf/jcgm/core/BeginTileArray.java
+++ b/src/net/sf/jcgm/core/BeginTileArray.java
@@ -87,8 +87,25 @@ public class BeginTileArray extends Command {
 		double tileSizeInPathDirection = boundingBoxSizeInPathDirection / this.nTilesInPathDirection;
 		double tileSizeInLineDirection = boundingBoxSizeInLineDirection / this.nTilesInLineDirection;
 
+		// ONLY FOR T6 COMPRESSED TILES:
+		// it can happen (this is true for some T6 compressed samples at least)
+		// that the nCellsInLineDirection is higher than the (amount of lines * nCellsPerTileInLineDirection);
+		// i.e. that each line does NOT have the same height; 
+		// therefore, always compute the height of the last tile so the TiffWritter is well set up  
+		int amountOfLastLineCellsInLineDirection =
+				// total height
+				this.nCellsInLineDirection
+						// sum of height of the first lines
+						- (this.nTilesInLineDirection - 1) * this.nCellsPerTileInLineDirection;
+
+		if (amountOfLastLineCellsInLineDirection != this.nCellsPerTileInLineDirection) {
+			Messages.getInstance().add(new Message(Message.Severity.INFO, getElementClass(), getElementCode(), 
+					"the amount of cells of the last line is different than the given amount of cells per line", toString()));
+		}
+		
 		d.setTileArrayInfo(new TileArrayInfo(startPosition, this.nTilesInPathDirection, this.nCellsPerTileInPathDirection,
-				this.nCellsPerTileInLineDirection, tileSizeInPathDirection, tileSizeInLineDirection));
+				this.nCellsPerTileInLineDirection, tileSizeInPathDirection, tileSizeInLineDirection, 
+				this.nTilesInLineDirection, amountOfLastLineCellsInLineDirection));
 	}
 
 	@Override

--- a/src/net/sf/jcgm/core/TileArrayInfo.java
+++ b/src/net/sf/jcgm/core/TileArrayInfo.java
@@ -36,6 +36,8 @@ public class TileArrayInfo {
 	private final int nTilesInPathDirection;
 	private final double tileSizeInPathDirection;
 	private final double tileSizeInLineDirection;
+	private final int nTilesInLineDirection;
+	private final int amountOfLastLineCellsInLineDirection;
 
 	/** current index in path direction */
 	private int pathIndex = 0;
@@ -52,8 +54,9 @@ public class TileArrayInfo {
 	private final int nCellsPerTileInLineDirection;
 
 	TileArrayInfo(Double startPosition, int nTilesInPathDirection,
-			int nCellsPerTileInPathDirection, int nCellsPerTileInLineDirection,
-			double tileSizeInPathDirection, double tileSizeInLineDirection) {
+				  int nCellsPerTileInPathDirection, int nCellsPerTileInLineDirection,
+				  double tileSizeInPathDirection, double tileSizeInLineDirection,
+				  int nTilesInLineDirection, int amountOfLastLineCellsInLineDirection) {
 		this.startPosition = startPosition;
 		this.currentPosition = new Point2D.Double(startPosition.x, startPosition.y);
 		this.nTilesInPathDirection = nTilesInPathDirection;
@@ -61,6 +64,8 @@ public class TileArrayInfo {
 		this.nCellsPerTileInLineDirection = nCellsPerTileInLineDirection;
 		this.tileSizeInPathDirection = tileSizeInPathDirection;
 		this.tileSizeInLineDirection = tileSizeInLineDirection;
+		this.nTilesInLineDirection = nTilesInLineDirection;
+		this.amountOfLastLineCellsInLineDirection = amountOfLastLineCellsInLineDirection;
 	}
 
 	int getCurrentPathIndex() {
@@ -97,6 +102,14 @@ public class TileArrayInfo {
 		return this.currentPosition;
 	}
 
+	public int getAmountOfLastLineCellsInLineDirection() {
+		return this.amountOfLastLineCellsInLineDirection;
+	}
+
+	boolean isLastLine() {
+		return this.lineIndex == this.nTilesInLineDirection - 1 ;
+	}
+	
 	/**
 	 * This will update the current position for the next tile.
 	 */

--- a/src/net/sf/jcgm/core/TileElement.java
+++ b/src/net/sf/jcgm/core/TileElement.java
@@ -161,7 +161,13 @@ abstract class TileElement extends Command {
 			}
 			TiffWriter writer = new TiffWriter();
 			writer.setImageWidth(tileArrayInfo.getNCellsPerTileInPathDirection());
-			writer.setImageHeight(tileArrayInfo.getNCellsPerTileInLineDirection());
+			int imageHeight = tileArrayInfo.getNCellsPerTileInLineDirection();
+			// it can happen that the nCellsInLineDirection is higher than the (amount of lines * nCellsPerTileInLineDirection)
+			// i.e. that each line does NOT have the same height; in that case get the correct height of the last tile	
+			if (tileArrayInfo.isLastLine()) {
+				imageHeight = tileArrayInfo.getAmountOfLastLineCellsInLineDirection();
+			} 
+			writer.setImageHeight(imageHeight);
 			writer.setCompressionType(CompressionType.T6);
 			writer.setImageData(this.bytes.array());
 			byte[] tiffBytes = writer.writeImage();

--- a/src/net/sf/jcgm/examples/Viewer.java
+++ b/src/net/sf/jcgm/examples/Viewer.java
@@ -48,8 +48,8 @@ public class Viewer extends JFrame {
 	private JButton nextButton;
 
 	public Viewer() {
-		this.testDir = new File("d:/software/webcgm21-ts/static10");
-		this.referenceDir = new File("d:/software/webcgm21-ts/static10/images");
+		this.testDir = new File("C:/Users/diaa/Desktop/temp/jcgm-debug/images");
+		this.referenceDir = new File("C:/Users/diaa/Desktop/temp/jcgm-debug");
 		this.currentIndex = 0;
 
 		initCgmFiles();
@@ -125,7 +125,7 @@ public class Viewer extends JFrame {
 		this.cgmFiles = this.testDir.listFiles(new FilenameFilter() {
 			@Override
 			public boolean accept(File dir, String name) {
-				return name.endsWith(".cgm") || name.endsWith(".cgm.gz");
+				return name.endsWith(".cgm") || name.endsWith(".cgm.gz") || name.endsWith(".CGM");
 			}
 		});
 
@@ -167,7 +167,7 @@ public class Viewer extends JFrame {
 		gb.weightx = 100;
 		gb.gridx++;
 		this.dumpCommandFileField = new JTextField(50);
-		this.dumpCommandFileField.setText("c:\\Documents and Settings\\xphc\\Desktop\\ammcommands.txt");
+		this.dumpCommandFileField.setText("c:\\Documents and Settings\\diaa\\Desktop\\temp\\jcgm-debug\\ammcommands.txt");
 		topPanel.add(this.dumpCommandFileField, gb);
 
 		gb.weightx = 1;


### PR DESCRIPTION
In case of tile having a T6 compression, the generation of temporary TIFF file could lead to an `ArrayIndexOutOfBoundsException`.
This commit fixes the TIFF file generation in case the given `nCellsInLineDirection `is higher than the (amount of lines * `nCellsPerTileInLineDirection`), by always computing the amount of cells for last row of tiles.

![image](https://user-images.githubusercontent.com/95964959/224726897-d5ce24e8-daf4-48f5-99aa-65bdbccbee58.png)