### PR TITLE
Fix split cgm issues

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 <project name="jcgm" default="jar">
 	
 	<!-- The core package -->
-	<property name="version-core" 			value="1.0.0"/>
+	<property name="version-core" 			value="1.0.1"/>
 	<property name="package-name-core" 		value="jcgm-core-${version-core}"/>
 	<property name="jar-name-core" 			value="${package-name-core}.jar"/>
 	<property name="jar-name-core-sources" 	value="${package-name-core}-sources.jar"/>

--- a/src/net/sf/jcgm/core/CGM.java
+++ b/src/net/sf/jcgm/core/CGM.java
@@ -154,7 +154,8 @@ public class CGM implements Cloneable {
 			long currentPosition = 0;
 			String currentFileName = null;
 
-			while ((c = Command.read(randomAccessFile)) != null) {
+			CGM dummyCgm = new CGM();
+			while ((c = Command.read(randomAccessFile, dummyCgm)) != null) {
 				if (c instanceof BeginMetafile) {
 					// the CGM files will be cut at the begin meta file command
 					if (currentFileName != null) {
@@ -220,8 +221,9 @@ public class CGM implements Cloneable {
 			long startPosition = 0;
 			long currentPosition = 0;
 			String currentFileName = null;
-
-			while ((c = Command.read(randomAccessFile)) != null) {
+			
+			CGM dummyCgm = new CGM();
+			while ((c = Command.read(randomAccessFile, dummyCgm)) != null) {
 				if (c instanceof BeginMetafile) {
 					// the CGM files will be cut at the begin meta file command
 					if (currentFileName != null) {

--- a/src/net/sf/jcgm/core/Command.java
+++ b/src/net/sf/jcgm/core/Command.java
@@ -763,10 +763,6 @@ public class Command implements Cloneable {
 		// default empty implementation
 	}
 	
-	public static Command read(DataInput in) throws IOException {
-		return read(in, null);
-	}
-	
 	/**
 	 * Reads one command from the given input stream.
 	 *


### PR DESCRIPTION
Fixed an issue when calling the public static split method, introduced with the thread-safety refactoring: we now need a dummy CGM instance to keep track of var updates when reading the commands.