### PR TITLE
Bug/xphc/468799 adapt header reading logic

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 <project name="jcgm" default="jar">
 	
 	<!-- The core package -->
-	<property name="version-core" 			value="2.1.0"/>
+	<property name="version-core" 			value="2.1.1"/>
 	<property name="package-name-core" 		value="jcgm-core-${version-core}"/>
 	<property name="jar-name-core" 			value="${package-name-core}.jar"/>
 	<property name="jar-name-core-sources" 	value="${package-name-core}-sources.jar"/>

--- a/src/net/sf/jcgm/core/CGM.java
+++ b/src/net/sf/jcgm/core/CGM.java
@@ -151,9 +151,12 @@ public class CGM implements Cloneable {
 		read(in, true);
 	}
 
-	private void read(DataInput in, boolean stopAtBeginPicture) throws IOException {
+	private void read(DataInput in, boolean stopEarly) throws IOException {
 		reset();
 		this.commands = new ArrayList<Command>(INITIAL_NUM_COMMANDS);
+		boolean foundVDCExtent = false;
+		boolean foundScalingMode = false;
+		
 		while (!this.endMetafileReached) {
 			Command c = Command.read(in, this);
 			if (c == null)
@@ -167,8 +170,16 @@ public class CGM implements Cloneable {
 			c.cleanUpArguments();
 			this.commands.add(c);
 
-			if (stopAtBeginPicture && c instanceof BeginPicture) {
-				break;
+			if (stopEarly) {
+				if (c instanceof VDCExtent) {
+					foundVDCExtent = true;
+				}
+				if (c instanceof ScalingMode) {
+					foundScalingMode = true;
+				}
+				if (foundVDCExtent && foundScalingMode) {
+					break;
+				}
 			}
 		}
 		


### PR DESCRIPTION
The logic to determine when the header is read has been changed from stopping at BeginPicture to stopping after VDCExtend and ScalingMode have been read.

This makes it compatible with more CGM files.